### PR TITLE
Fix packing attribute with strict mode in GCC

### DIFF
--- a/include/coff/coff.h
+++ b/include/coff/coff.h
@@ -31,8 +31,7 @@
 #include <stdbool.h>
 #include "../orl_pack.h"
 
-ORL_PACKED
-struct coff_file_header {
+ORL_PACKED_STRUCT coff_file_header {
     uint16_t cpu_type;
     uint16_t num_sections;
     uint32_t time_stamp;
@@ -46,8 +45,7 @@ struct coff_file_header {
 
 #define COFF_SEC_NAME_LEN 8
 
-ORL_PACKED
-struct coff_section_header{
+ORL_PACKED_STRUCT coff_section_header{
     char name[COFF_SEC_NAME_LEN];
     uint32_t virtsize;
     uint32_t offset;
@@ -62,8 +60,7 @@ struct coff_section_header{
 
 #define COFF_SECTION_HEADER_SIZE sizeof(coff_section_header)
 
-ORL_PACKED
-struct coff_reloc {
+ORL_PACKED_STRUCT coff_reloc {
     uint32_t offset;
     uint32_t sym_tab_index;
     uint16_t type;
@@ -75,12 +72,10 @@ struct coff_reloc {
 
 /* typedef struct _IMAGE_SYMBOL in WINNT.H */
 
-ORL_PACKED
-struct coff_symbol {
+ORL_PACKED_STRUCT coff_symbol {
     union {
         char name_string[COFF_SYM_NAME_LEN];
-        ORL_PACKED
-        struct {
+        ORL_PACKED_STRUCT {
             uint32_t zeros;
             uint32_t offset;
         } non_name;
@@ -98,8 +93,7 @@ struct coff_symbol {
 #define _CoffBaseType( sym_type )   ( (sym_type) & 0xf )
 #define _CoffComplexType( sym_type )    ( ( (sym_type) >> 4 ) & 0xf )
 
-ORL_PACKED
-struct coff_sym_func {
+ORL_PACKED_STRUCT coff_sym_func {
     uint32_t bf;
     uint32_t size;
     uint32_t linenum;
@@ -107,8 +101,7 @@ struct coff_sym_func {
     char unused[3];
 };
 
-ORL_PACKED
-struct coff_sym_bfef {
+ORL_PACKED_STRUCT coff_sym_bfef {
     char unused1[4];
     uint16_t linenum;
     char unused2[6];
@@ -116,8 +109,7 @@ struct coff_sym_bfef {
     char unused3[2];
 };
 
-ORL_PACKED
-struct coff_sym_weak {
+ORL_PACKED_STRUCT coff_sym_weak {
     uint32_t tag_index;
     uint32_t characteristics;
     char unused1[10];
@@ -126,8 +118,7 @@ struct coff_sym_weak {
 #define COFF_FILE_NAME_LEN 18
 typedef char coff_sym_file[COFF_FILE_NAME_LEN];
 
-ORL_PACKED
-struct coff_sym_section {
+ORL_PACKED_STRUCT coff_sym_section {
     uint32_t length;
     uint16_t num_relocs;
     uint16_t num_line_numbers;
@@ -137,8 +128,7 @@ struct coff_sym_section {
     char unused[3];
 };
 
-ORL_PACKED
-struct coff_line_num {
+ORL_PACKED_STRUCT coff_line_num {
     union {
         uint32_t     symbol_table_index;
         uint32_t     RVA;
@@ -473,14 +463,12 @@ enum {
  * adc qword ptr [asdf], 12345678h
  */
 
-ORL_PACKED
-struct coff_image_data_directory {
+ORL_PACKED_STRUCT coff_image_data_directory {
     uint32_t rva;
     uint32_t size;
 };
 
-ORL_PACKED
-struct coff_opt_hdr {
+ORL_PACKED_STRUCT coff_opt_hdr {
     uint16_t magic; /*standard fields */
     uint8_t l_major;
     uint8_t l_minor;
@@ -527,8 +515,7 @@ struct coff_opt_hdr {
 
 /*#define COFF_OPT_HDR_SIZE sizeof( coff_opt_hdr ) */
 
-ORL_PACKED
-struct coff_opt_hdr64 {
+ORL_PACKED_STRUCT coff_opt_hdr64 {
     uint16_t magic; /*standard fields */
     uint8_t l_major;
     uint8_t l_minor;
@@ -582,8 +569,7 @@ struct coff_opt_hdr64 {
 
 #define IMPORT_OBJECT_HDR_SIG2  0xffff
 
-ORL_PACKED
-struct coff_import_object_header {
+ORL_PACKED_STRUCT coff_import_object_header {
     uint16_t sig1;       /* Must be IMAGE_FILE_MACHINE_UNKNOWN */
     uint16_t sig2;       /* Must be IMPORT_OBJECT_HDR_SIG2. */
     uint16_t version;

--- a/include/coff/cofftype.h
+++ b/include/coff/cofftype.h
@@ -110,8 +110,7 @@ struct coff_reloc_assoc_struct {
     orl_reloc relocs;
 };
 
-ORL_PACKED
-struct coff_sec_handle_struct  {
+ORL_PACKED_STRUCT coff_sec_handle_struct  {
     orl_file_format file_format;
     coff_file_handle coff_file_hnd;
     coff_sec_handle next;
@@ -132,8 +131,7 @@ struct coff_sec_handle_struct  {
     bool                relocs_done     : 1;
 };
 
-ORL_PACKED
-struct coff_symbol_handle_struct {
+ORL_PACKED_STRUCT coff_symbol_handle_struct {
     orl_file_format file_format;
     coff_file_handle coff_file_hnd;
     orl_symbol_binding binding;
@@ -146,7 +144,7 @@ struct coff_symbol_handle_struct {
 
 typedef struct pe_header_struct pe_header;
 
-struct pe_header_struct {
+ORL_PACKED_STRUCT pe_header_struct {
     char MZ[2];
     char space[0x3a];
     short offset;
@@ -156,12 +154,12 @@ typedef union pe_opt_hdr_struct pe_opt_hdr;
 
 union pe_opt_hdr_struct {
     uint16_t magic;
-    struct {
+    ORL_PACKED_STRUCT {
         uint16_t magic;
         char space[94];
         uint32_t export_table_rva;
     } pe32;
-    struct {
+    ORL_PACKED_STRUCT {
         uint16_t magic;
         char space[110];
         uint32_t export_table_rva;

--- a/include/exeelf.h
+++ b/include/exeelf.h
@@ -55,8 +55,7 @@ typedef uint64_t Elf64_Xword;
 
 #define EI_NIDENT 16
 
-ORL_PACKED
-struct Elf32_Ehdr {
+ORL_PACKED_STRUCT Elf32_Ehdr {
     uint8_t e_ident[EI_NIDENT];        /* signature & ID info */
     Elf32_Half e_type;                 /* file type (i.e. obj file, exe file) */
     Elf32_Half e_machine;              /* required architecture */
@@ -77,8 +76,7 @@ struct Elf32_Ehdr {
 };
 
 /* ELF-64 header: identical to Elf32_Ehdr up to and including e_version */
-ORL_PACKED
-struct Elf64_Ehdr {
+ORL_PACKED_STRUCT Elf64_Ehdr {
     uint8_t e_ident[EI_NIDENT];        /* signature & ID info */
     Elf64_Half e_type;                 /* file type (i.e. obj file, exe file) */
     Elf64_Half e_machine;              /* required architecture */
@@ -279,8 +277,7 @@ struct Elf64_Ehdr {
 
 /* section header */
 
-ORL_PACKED
-struct Elf32_Shdr {
+ORL_PACKED_STRUCT Elf32_Shdr {
     Elf32_Word  sh_name;        /* name of the section */
     Elf32_Word  sh_type;        /* section type */
     Elf32_Word  sh_flags;
@@ -293,8 +290,7 @@ struct Elf32_Shdr {
     Elf32_Word  sh_entsize;     /* entry size for sects with fixed sized entries */
 };
 
-ORL_PACKED
-struct Elf64_Shdr {
+ORL_PACKED_STRUCT Elf64_Shdr {
     Elf64_Word  sh_name;        /* name of the section */
     Elf64_Word  sh_type;        /* section type */
     Elf64_Xword sh_flags;
@@ -356,8 +352,7 @@ struct Elf64_Shdr {
 
 /* symbol table entry */
 
-ORL_PACKED
-struct Elf32_Sym {
+ORL_PACKED_STRUCT Elf32_Sym {
     Elf32_Word  st_name;        /* symbol name index into string table */
     Elf32_Addr  st_value;       /* symbol "value" */
     Elf32_Word  st_size;        /* symbol size */
@@ -366,8 +361,7 @@ struct Elf32_Sym {
     Elf32_Half  st_shndx;       /* section index */
 };
 
-ORL_PACKED
-struct Elf64_Sym {
+ORL_PACKED_STRUCT Elf64_Sym {
     Elf64_Word  st_name;        /* symbol name index into string table */
     uint8_t  st_info;           /* symbol's type and binding attribs. */
     uint8_t  st_other;          /* no meaning yet. */
@@ -404,27 +398,23 @@ struct Elf64_Sym {
 
 /* relocation entries */
 
-ORL_PACKED
-struct Elf32_Rel {
+ORL_PACKED_STRUCT Elf32_Rel {
     Elf32_Addr  r_offset;       /* place to apply reloc (from begin of section) */
     Elf32_Word  r_info;         /* symbol idx, and type of reloc */
 };
 
-ORL_PACKED
-struct Elf32_Rela {
+ORL_PACKED_STRUCT Elf32_Rela {
     Elf32_Addr  r_offset;       /* place to apply reloc (from begin of section) */
     Elf32_Word  r_info;         /* symbol idx, and type of reloc */
     Elf32_Sword r_addend;       /* value used as a basis for the reloc. */
 };
 
-ORL_PACKED
-struct Elf64_Rel {
+ORL_PACKED_STRUCT Elf64_Rel {
     Elf64_Addr  r_offset;       /* place to apply reloc (from begin of section) */
     Elf64_Xword r_info;         /* symbol idx, and type of reloc */
 };
 
-ORL_PACKED
-struct Elf64_Rela {
+ORL_PACKED_STRUCT Elf64_Rela {
     Elf64_Addr  r_offset;       /* place to apply reloc (from begin of section) */
     Elf64_Xword r_info;         /* symbol idx, and type of reloc */
     Elf64_Sxword r_addend;      /* value used as a basis for the reloc. */
@@ -646,8 +636,7 @@ struct Elf64_Rela {
 
 /* program header */
 
-ORL_PACKED
-struct Elf32_Phdr {
+ORL_PACKED_STRUCT Elf32_Phdr {
     Elf32_Word  p_type;         /* type of segment */
     Elf32_Off   p_offset;       /* offset of segment from beginnning of file */
     Elf32_Addr  p_vaddr;        /* segment virtual address */
@@ -658,8 +647,7 @@ struct Elf32_Phdr {
     Elf32_Word  p_align;        /* segment align value (in mem & file) */
 };
 
-ORL_PACKED
-struct Elf64_Phdr {
+ORL_PACKED_STRUCT Elf64_Phdr {
     Elf64_Word  p_type;         /* type of segment */
     Elf64_Word  p_flags;        /* segment flags */
     Elf64_Off   p_offset;       /* offset of segment from beginnning of file */
@@ -699,8 +687,7 @@ struct Elf64_Phdr {
 
 /* note entry format */
 
-ORL_PACKED
-struct Elf_Note {
+ORL_PACKED_STRUCT Elf_Note {
     uint32_t     n_namesz;   /* length of name */
     uint32_t     n_descsz;   /* length of descriptor */
     uint32_t     n_type;     /* user defined "type" of the note */
@@ -716,8 +703,7 @@ struct Elf_Note {
 
 /* dynamic segment entry information. */
 
-ORL_PACKED
-struct El32_Dyn {
+ORL_PACKED_STRUCT El32_Dyn {
     Elf32_Sword         d_tag;
     union {
         Elf32_Word      d_val;
@@ -800,8 +786,7 @@ typedef unsigned long INITTERM( unsigned long modhandle, unsigned long flag );
 
 /* operating system information */
 
-ORL_PACKED
-struct Elf32_Os {
+ORL_PACKED_STRUCT Elf32_Os {
     Elf32_Word os_type;
     Elf32_Word os_size;
 };
@@ -819,8 +804,7 @@ struct Elf32_Os {
 
 /* OS/2-specific information */
 
-ORL_PACKED
-struct Elf32_OS2Info {
+ORL_PACKED_STRUCT Elf32_OS2Info {
     unsigned char os2_sessiontype;
     unsigned char os2_sessionflags;
     unsigned char os2_reserved[14];
@@ -835,8 +819,7 @@ struct Elf32_OS2Info {
 
 /* import table entry */
 
-ORL_PACKED
-struct Elf32_Import {
+ORL_PACKED_STRUCT Elf32_Import {
     Elf32_Word imp_ordinal;
     Elf32_Word imp_name;
     Elf32_Word imp_info;
@@ -853,8 +836,7 @@ struct Elf32_Import {
 
 /* export table entry */
 
-ORL_PACKED
-struct Elf32_Export {
+ORL_PACKED_STRUCT Elf32_Export {
     Elf32_Word exp_ordinal;
     Elf32_Word exp_symbol;
     Elf32_Word exp_name;
@@ -865,7 +847,7 @@ struct Elf32_Export {
 
 #define RH_NIDENT       16
 
-struct Elf32_Rhdr {
+ORL_PACKED_STRUCT Elf32_Rhdr {
     unsigned char rh_ident[RH_NIDENT];
     Elf32_Off rh_name;
     Elf32_Word rh_itnum;
@@ -910,8 +892,7 @@ struct Elf32_Rhdr {
 
 #define RI_NIDENT       4
 
-ORL_PACKED
-struct Elf32_Ritem {
+ORL_PACKED_STRUCT Elf32_Ritem {
     unsigned char       ri_ident[RI_NIDENT];
     Elf32_Word          ri_type;
     Elf32_Off           ri_typename;
@@ -935,16 +916,14 @@ struct Elf32_Ritem {
 
 /* demangle information structure */
 
-ORL_PACKED
-struct Elf32_Demangle {
+ORL_PACKED_STRUCT Elf32_Demangle {
     Elf32_Word  idm_dllname;
     Elf32_Word  idm_initparms;
 };
 
 /* default library structure */
 
-ORL_PACKED
-struct Elf32_Library {
+ORL_PACKED_STRUCT Elf32_Library {
     Elf32_Word  lib_name;
 };
 

--- a/include/exepe.h
+++ b/include/exepe.h
@@ -60,15 +60,13 @@ enum {
 
 #define OLD_PE_TBL_NUMBER 9
 
-ORL_PACKED
-struct pe_hdr_table_entry{
+ORL_PACKED_STRUCT pe_hdr_table_entry{
     pe_va rva;
     uint32_t size;
 };
 
 /* PE32 header structure */
-ORL_PACKED
-struct pe_header{
+ORL_PACKED_STRUCT pe_header{
     uint32_t signature;
     uint16_t cpu_type;
     uint16_t num_objects;
@@ -111,8 +109,7 @@ struct pe_header{
 };
 
 /* PE32+ header structure */
-ORL_PACKED
-struct pe_header64 {
+ORL_PACKED_STRUCT pe_header64 {
     uint32_t         signature;
     uint16_t         cpu_type;
     uint16_t         num_objects;
@@ -243,8 +240,7 @@ enum {
 
 /* PE object table structure */
 #define PE_OBJ_NAME_LEN 8
-ORL_PACKED
-struct pe_object {
+ORL_PACKED_STRUCT pe_object {
     char name[PE_OBJ_NAME_LEN];
     uint32_t virtual_size;
     pe_va rva;
@@ -290,8 +286,7 @@ struct pe_object {
 #define PE_OBJ_ALIGN_SHIFT      20
 
 /* PE export directory table structure */
-ORL_PACKED
-struct pe_export_directory {
+ORL_PACKED_STRUCT pe_export_directory {
     uint32_t flags;
     uint32_t time_stamp;
     uint16_t major;
@@ -307,8 +302,7 @@ struct pe_export_directory {
 
 
 /* PE import directory table structure */
-ORL_PACKED
-struct pe_import_directory {
+ORL_PACKED_STRUCT pe_import_directory {
     pe_va import_lookup_table_rva;        /* was flags */
     uint32_t time_stamp;
     uint16_t major;
@@ -322,8 +316,7 @@ struct pe_import_directory {
 #define PE_IMPORT_BY_ORDINAL    0x80000000UL
 
 /* PE import hint-name table structure */
-ORL_PACKED
-struct pe_hint_name_entry {
+ORL_PACKED_STRUCT pe_hint_name_entry {
     uint16_t hint;
     uint8_t name[2]; /* variable size, padded to even boundry */
 };
@@ -333,8 +326,7 @@ struct pe_hint_name_entry {
 /* PE fixup table structure */
 typedef uint16_t pe_fixup_entry;
 
-ORL_PACKED
-struct pe_fixup_header {
+ORL_PACKED_STRUCT pe_fixup_header {
     pe_va page_rva;
     uint32_t block_size;
 /*  pe_fixup_entry      fixups[] */     /* variable size */
@@ -342,8 +334,7 @@ struct pe_fixup_header {
 
 #define PEUP 12
 
-ORL_PACKED
-struct old_pe_fixup_entry {
+ORL_PACKED_STRUCT old_pe_fixup_entry {
     pe_va virt_addr;
     uint32_t value;
     uint16_t type;
@@ -374,8 +365,7 @@ struct old_pe_fixup_entry {
 #define DEBUG_TYPE_CODEVIEW   2
 #define DEBUG_TYPE_MISC       4
 
-ORL_PACKED
-struct debug_directory {
+ORL_PACKED_STRUCT debug_directory {
     uint32_t flags;
     uint32_t time_stamp;
     uint16_t major;
@@ -387,8 +377,7 @@ struct debug_directory {
 };
 
 /* PE DEBUG_TYPE_MISC data */
-ORL_PACKED
-struct debug_misc_dbgdata {
+ORL_PACKED_STRUCT debug_misc_dbgdata {
     uint32_t data_type;          /* 1 == filename of debug info file */
     uint32_t length;             /* size of this data block */
     uint32_t unicode;            /* LSB is unicode flag, rest is reserved */
@@ -397,7 +386,7 @@ struct debug_misc_dbgdata {
 };
 
 /* procedure descriptor format for alpha and powerpc */
-struct procedure_descriptor {
+ORL_PACKED_STRUCT procedure_descriptor {
     uint32_t beginaddress;
     uint32_t endaddress;
     uint32_t exceptionhandler;
@@ -406,8 +395,7 @@ struct procedure_descriptor {
 };
 
 /* PE resource directory structure */
-ORL_PACKED
-struct resource_dir_header {
+ORL_PACKED_STRUCT resource_dir_header {
     uint32_t flags;
     uint32_t time_stamp;
     uint16_t major;
@@ -422,8 +410,7 @@ A resource directory is a resource_dir_header followed immediately by
 ordered sorted name entries then sorted id entries.
 */
 
-ORL_PACKED
-struct resource_dir_entry {
+ORL_PACKED_STRUCT resource_dir_entry {
     uint32_t id_name;        /* see below */
     pe_va entry_rva;      /* see below */
 };
@@ -441,7 +428,7 @@ If entry_rva & PE_RESOURCE_MASK_ON the entry_rva & PE_RESOURCE_MASK is a rva
 otherwise it is a rva to a resource_entry.
 */
 
-struct resource_entry {
+ORL_PACKED_STRUCT resource_entry {
     uint32_t data_rva;       /* relative to Image Base */
     uint32_t size;
     uint32_t code_page;

--- a/include/omf/pcobj.h
+++ b/include/omf/pcobj.h
@@ -40,8 +40,7 @@
 /*
  * Library stuff
  */
-ORL_PACKED
-struct lib_header {
+ORL_PACKED_STRUCT lib_header {
     uint8_t cmd;
     uint16_t length;
     uint32_t dict_start;
@@ -245,14 +244,12 @@ enum {
     LOC_MS_LINK_OFFSET_32= 13       /* like OFFSET_32 but loader resolved*/
 };
 
-ORL_PACKED
-struct obj_record {
+ORL_PACKED_STRUCT obj_record {
     uint8_t command;
     uint16_t length;
 };
 
-ORL_PACKED
-struct obj_name {
+ORL_PACKED_STRUCT obj_name {
     uint8_t len;
     char name[1];
 };
@@ -313,8 +310,7 @@ enum {
     target processor.
 */
 
-ORL_PACKED
-struct cpu_data{
+ORL_PACKED_STRUCT cpu_data{
     char processor;
     char mem_model;
     char unknown;

--- a/include/orl_pack.h
+++ b/include/orl_pack.h
@@ -2,13 +2,17 @@
 
 #if defined __WATCOMC__
 #define ORL_PACKED _Packed
+#define ORL_PACKED_STRUCT ORL_PACKED struct
 #elif defined _MSC_VER
 #define ORL_PACKED _declspec(align(1))
+#define ORL_PACKED_STRUCT ORL_PACKED struct
 #elif defined __GNUC__
 #define ORL_PACKED __attribute__((__packed__))
+#define ORL_PACKED_STRUCT struct ORL_PACKED
 #else
 #error NO PACKING
 #define ORL_PACKED
+#define ORL_PACKED_STRUCT struct
 #endif
 
 #endif

--- a/include/orlglobl.h
+++ b/include/orlglobl.h
@@ -101,8 +101,8 @@ typedef enum {
     ORL_UNRECOGNIZED_FORMAT
 } orl_file_format;
 
-ORL_PACKED
-struct sorl_linnum {
+ORL_PACKED_STRUCT
+sorl_linnum {
     uint16_t linnum;
     uint32_t off;
 };


### PR DESCRIPTION
In strict mode, GCC requires the __attribute__ to be after the struct keyword in C.